### PR TITLE
Do not transform ES2015 modules to CommonJS to allow Tree Shaking with WebPack2 and Babel6 http://2ality.com/2015/12/webpack-tree-shaking.html.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  presets: ['es2015', 'react', 'stage-0']
+  presets: [['es2015', {"modules": false}], 'react', 'stage-0']
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-react/61)
<!-- Reviewable:end -->
