### PR TITLE
Automatically assign code reviews from Doppins.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Automatically assign the reviews from Doppins.
+package.json @pcorpet @zozoens31


### PR DESCRIPTION
See: https://help.github.com/articles/about-codeowners/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-react/244)
<!-- Reviewable:end -->
