### PR TITLE
Revert "[Doppins] Upgrade dependency webpack to 4.10.0 (#522)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "svgo-loader": "2.1.0",
     "unused-files-webpack-plugin": "3.4.0",
     "url-loader": "1.0.1",
-    "webpack": "4.10.0",
+    "webpack": "4.9.1",
     "webpack-cli": "2.1.4",
     "webpack-dev-server": "3.1.4",
     "webpack-pwa-manifest": "3.6.2",


### PR DESCRIPTION
Got the following error on bob-emploi-internal:
```/usr/app/node_modules/babel-loader/lib/index.js??ref--10!/usr/app/src/components/share.jsx
RuntimeTemplate.moduleId(): Module /usr/app/node_modules/react-share/es/FacebookShareButton.js has no id. This should not happen.```

This reverts commit fc8c9356bdb67bd03594e19fae529b12121b6b02.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-react/523)
<!-- Reviewable:end -->
