### PR TITLE
Revert "[Doppins] Upgrade dependency eslint to 5.14.0 (#825)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "emoji-regex": "7.0.3",
     "es6-promise": "4.2.5",
     "es6-set-proptypes": "1.0.0",
-    "eslint": "5.14.0",
+    "eslint": "5.13.0",
     "eslint-import-resolver-webpack": "0.11.0",
     "eslint-loader": "2.1.2",
     "eslint-plugin-import": "2.16.0",


### PR DESCRIPTION
This reverts commit fe9e6526127fa65f43d8345027e8574eb22ab035.

We can reenable it once https://github.com/eslint/eslint/issues/11402 is
fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-react/829)
<!-- Reviewable:end -->
