### PR TITLE
[AutoUpdate] Update dependency eslint-plugin-you-dont-need-lodash-underscore to version 6.7.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-react": "7.14.3",
     "eslint-plugin-unicorn": "9.1.1",
-    "eslint-plugin-you-dont-need-lodash-underscore": "6.5.0",
+    "eslint-plugin-you-dont-need-lodash-underscore": "6.7.0",
     "exports-loader": "0.7.0",
     "file-loader": "4.1.0",
     "firebase": "6.5.0",


### PR DESCRIPTION
[AutoUpdate] Update dependency eslint-plugin-you-dont-need-lodash-underscore to version 6.6.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-react/1113)
<!-- Reviewable:end -->
