### PR TITLE
Revert "[AutoUpdate] Update dependency eslint-plugin-you-dont-need-lodash-underscore to version 6.7.1. (#1187)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-react": "7.14.3",
     "eslint-plugin-react-hooks": "2.0.1",
     "eslint-plugin-unicorn": "10.0.0",
-    "eslint-plugin-you-dont-need-lodash-underscore": "6.7.1",
+    "eslint-plugin-you-dont-need-lodash-underscore": "6.7.0",
     "exports-loader": "0.7.0",
     "file-loader": "4.1.0",
     "firebase": "6.6.1",


### PR DESCRIPTION
This reverts commit 4869b30410d3c9fe76b23f3cbc56f7ab12d2ec2c.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-react/1188)
<!-- Reviewable:end -->
