### PR TITLE
No need for react-share types now that we've upgraded to react-share v4+ which has TypeScript types embedded.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@types/react-router": "5.1.8",
     "@types/react-router-dom": "5.1.5",
     "@types/react-select": "3.0.19",
-    "@types/react-share": "3.0.3",
     "@types/react-test-renderer": "16.9.3",
     "@types/redux-mock-store": "1.0.2",
     "@types/redux-sentry-middleware": "0.1.2",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-react/2360)
<!-- Reviewable:end -->
