### PR TITLE
Drop useless and deprecated @types/jspdf.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@types/imagemin-optipng": "5.2.0",
     "@types/imagemin-svgo": "9.0.0",
     "@types/json-stable-stringify": "1.0.32",
-    "@types/jspdf": "1.3.3",
     "@types/karma": "6.3.0",
     "@types/lodash": "4.14.169",
     "@types/minimist": "1.2.1",


### PR DESCRIPTION
JsPDF defines its types directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-react/3237)
<!-- Reviewable:end -->
