### PR TITLE
Restrict webpack-dev-middleware to 5.2.2.

### DIFF
--- a/.circleci/test_resolutions.sh
+++ b/.circleci/test_resolutions.sh
@@ -5,7 +5,7 @@ while read dep; do
     read resolution_version
     package="$(sed -e 's/^.*\*\*\///' <<< $dep)"
     version="$(jq -r .dependencies[\""$package"\"] package.json)"
-    if [ "$version" != "$resolution_version" ]; then
+    if [ "$version" != "$resolution_version" ] && [ "$version" != "null" ]; then
         echo "Need $package $version but got $resolution_version in resolutions"
         exit 1
     fi

--- a/package.json
+++ b/package.json
@@ -184,7 +184,8 @@
   "name": "bayesimpact-react",
   "resolutions": {
     "@sentry/browser": "6.16.1",
-    "webpack": "5.65.0"
+    "webpack": "5.65.0",
+    "webpack-dev-middleware": "5.2.2"
   },
   "scripts": {
     "clean": "rimraf dist/*",


### PR DESCRIPTION
Version 5.3.0 introduces types which are not properly compatible
with @types/webpack-dev-server that we uses for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-react/3841)
<!-- Reviewable:end -->
