### PR TITLE
Revert "Bump i18next from 21.6.3 to 21.6.4"

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "glob": "7.2.0",
     "google-protobuf": "3.19.1",
     "html-webpack-plugin": "5.5.0",
-    "i18next": "21.6.4",
+    "i18next": "21.6.3",
     "i18next-browser-languagedetector": "6.1.2",
     "imagemin": "8.0.1",
     "imagemin-mozjpeg": "9.0.0",


### PR DESCRIPTION
Reverts bayesimpact/docker-react#3861 because of https://github.com/i18next/react-i18next/issues/1434

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-react/3863)
<!-- Reviewable:end -->
