### PR TITLE
Revert "Bump react-i18next from 11.15.1 to 11.15.2 (#3857)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "react-google-login": "5.2.2",
     "react-height": "3.0.2",
     "react-hot-loader": "4.13.0",
-    "react-i18next": "11.15.2",
+    "react-i18next": "11.15.1",
     "react-lazyload": "3.2.0",
     "react-markdown": "7.1.2",
     "react-redux": "7.2.6",


### PR DESCRIPTION
This reverts commit fdaf1414ec0fb338238b4e75a2e8f3a050901287.
See https://github.com/i18next/react-i18next/issues/1434

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-react/3881)
<!-- Reviewable:end -->
