### PR TITLE
Drop @types/react-select as types are now embedded in react-selecet v5+

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@types/react-redux": "7.1.22",
     "@types/react-router": "5.1.18",
     "@types/react-router-dom": "5.3.3",
-    "@types/react-select": "4.0.18",
     "@types/react-test-renderer": "17.0.1",
     "@types/redux-mock-store": "1.0.3",
     "@types/redux-sentry-middleware": "0.2.1",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-react/3965)
<!-- Reviewable:end -->
