### PR TITLE
[Small Fix] Quickly skip to 6.19.1 of @sentry/browser as previous version is broken.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "@mysticatea/eslint-plugin": "13.0.0",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.4",
     "@react-firebase/auth": "0.2.10",
-    "@sentry/browser": "6.19.0",
-    "@sentry/react": "6.19.0",
+    "@sentry/browser": "6.19.1",
+    "@sentry/react": "6.19.1",
     "@types/amplitude-js": "8.16.0",
     "@types/chai": "4.3.0",
     "@types/chai-almost": "1.0.1",
@@ -182,7 +182,7 @@
   },
   "name": "bayesimpact-react",
   "resolutions": {
-    "@sentry/browser": "6.19.0",
+    "@sentry/browser": "6.19.1",
     "webpack": "5.70.0"
   },
   "scripts": {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-react/4110)
<!-- Reviewable:end -->
