### PR TITLE
(CFG) - Update package.json Fix #4200

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@types/chai-almost": "1.0.1",
     "@types/imagemin-mozjpeg": "8.0.1",
     "@types/imagemin-optipng": "5.2.1",
-    "@types/imagemin-svgo": "10.0.1",
+    "@types/imagemin-svgo": "9.0.0",
     "@types/json-stable-stringify": "1.0.34",
     "@types/karma": "6.3.3",
     "@types/lodash": "4.14.181",


### PR DESCRIPTION
**Related Issue:** https://github.com/bayesimpact/docker-react/issues/4200

Downgrading imagemin-svgo to version 9.0.0, avoiding the latest version (10.0.0) has ES module support only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-react/4202)
<!-- Reviewable:end -->
