### PR TITLE
Cap webpack-dev-middleware to 5.3.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,8 @@
     "@types/react-dom": "17.0.14",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "webpack": "5.72.0"
+    "webpack": "5.72.0",
+    "webpack-dev-middleware": "5.3.1"
   },
   "scripts": {
     "clean": "rimraf dist/*",


### PR DESCRIPTION
See https://github.com/webpack/webpack-dev-middleware/issues/1270

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/docker-react/4203)
<!-- Reviewable:end -->
